### PR TITLE
Fix ambiguous python shebangs

### DIFF
--- a/rpm/eucaconsole
+++ b/rpm/eucaconsole
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 import sys
 from pkg_resources import load_entry_point

--- a/rpm/eucaconsole.requires.patch
+++ b/rpm/eucaconsole.requires.patch
@@ -1,7 +1,7 @@
 --- eucaconsole.py	2016-03-30 13:27:47.306905718 -0700
 +++ eucaconsole.py	2016-03-30 13:27:17.788862690 -0700
 @@ -1,7 +1,8 @@
- #!/usr/bin/python -tt
+ #!/usr/bin/python2 -tt
 +__requires__ = ['pyramid', 'zope.interface>=4.0.4', 'beaker']
  import sys
  from pkg_resources import load_entry_point


### PR DESCRIPTION
Fix ambiguous python shebangs as these can otherwise cause build failures.

Example packaging guidelines covering python 2 use:
https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_multiple_python_runtimes

Build:  ocd/job/eucalyptus-internal-5-build-random-rpms/57/
QA run: ocd/job/eucalyptus-5-qa-suite/55/