### PR TITLE
eucaconsole init script nginx daemon command missing pidfile option

### DIFF
--- a/rpm/eucaconsole.init
+++ b/rpm/eucaconsole.init
@@ -71,7 +71,7 @@ start() {
 
     if [ "x$NGINX_FLAGS" != xNO ]; then
         echo -n "Starting eucaconsole nginx: "
-        daemon /usr/sbin/nginx -c /etc/eucaconsole/nginx.conf $NGINX_FLAGS
+        daemon --pidfile ${NGINXPIDFILE} /usr/sbin/nginx -c /etc/eucaconsole/nginx.conf $NGINX_FLAGS
         [ $? -eq 0 ] && touch /var/lock/subsys/eucaconsole-nginx
         echo
     fi


### PR DESCRIPTION
The init script for eucaconsole is missing an option for the daemon when starting nginx. In the ansible playbook we are patching this file:

https://github.com/AppScale/ats-deploy/blob/6dd0d9d64d6e0266b101f3d15a756c19ba3e79c8/roles/console/tasks/main.yml#L41-L45

We can remove the work around from the playbook after the fix is merged.

Fixes corymbia/eucalyptus#175