### PR TITLE
Display security group identifier in details view

### DIFF
--- a/eucaconsole/templates/securitygroups/securitygroup_view.pt
+++ b/eucaconsole/templates/securitygroups/securitygroup_view.pt
@@ -57,6 +57,10 @@
                         <div class="large-2 small-3 columns"><label i18n:translate="">Name</label></div>
                         <div class="large-10 small-9 columns field inline breakword">${security_group_name}</div>
                     </div>
+                    <div class="row controls-wrapper readonly" tal:condition="security_group">
+                        <div class="large-2 small-3 columns"><label i18n:translate="">ID</label></div>
+                        <div class="large-10 small-9 columns field inline breakword">${security_group_id}</div>
+                    </div>
                     <div tal:condition="not security_group" tal:omit-tag="">
                         ${panel('form_field', field=securitygroup_form['description'], ng_attrs={'model': 'securityGroupDescription'}, leftcol_width=3, rightcol_width=9, **{'pattern': securitygroup_form.sgroup_description_pattern})}
                     </div>

--- a/eucaconsole/views/securitygroups.py
+++ b/eucaconsole/views/securitygroups.py
@@ -248,6 +248,7 @@ class SecurityGroupView(TaggedItemView):
         self.render_dict = dict(
             security_group=self.security_group,
             security_group_name=self.escape_braces(self.security_group.name) if self.security_group else '',
+            security_group_id=self.security_group.id if self.security_group else '',
             security_group_vpc=self.security_group_vpc,
             securitygroup_form=self.securitygroup_form,
             delete_form=self.delete_form,


### PR DESCRIPTION
The details view now includes the security group identifier.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=916
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/225/
Test: /job/eucalyptus-5-qa-fast/168/

Fixes corymbia/eucaconsole#19